### PR TITLE
#10 注文履歴と購入明細テーブルへのデータ投入処理

### DIFF
--- a/lib/model/cart.php
+++ b/lib/model/cart.php
@@ -38,6 +38,14 @@ function cart_total_price($db, $user_id) {
 	return $row['total_price'];
 }
 
+function cart_sum($cart_items) {
+	$sum_price = 0;
+	foreach ($cart_items as $cart_item) {
+		$sum_price += $cart_item['price'] * $cart_item['amount'];
+	}
+	return $sum_price;
+}
+
 /**
  * @param PDO $db
  * @param int $user_id

--- a/lib/model/cart.php
+++ b/lib/model/cart.php
@@ -24,23 +24,24 @@ function cart_is_exists_item($db, $user_id, $item_id) {
  * @param int $user_id
  * @return int | NULL
  */
-function cart_total_price($db, $user_id) {
-	$sql =
-	'SELECT sum(price * amount) as total_price
- 	FROM carts JOIN items
- 	ON carts.item_id = items.id
-	WHERE items.status = 1 AND user_id = ?;';
-	$params = array($user_id); 
-	$row = db_select_one($db, $sql, $params);
-	if (empty($row)) {
-		return null;
-	}
-	return $row['total_price'];
-}
+// function cart_total_price($db, $user_id) {
+// 	$sql =
+// 	'SELECT sum(price * amount) as total_price
+//  	FROM carts JOIN items
+//  	ON carts.item_id = items.id
+// 	WHERE items.status = 1 AND user_id = ?;';
+// 	$params = array($user_id); 
+// 	$row = db_select_one($db, $sql, $params);
+// 	if (empty($row)) {
+// 		return null;
+// 	}
+// 	return $row['total_price'];
+// }
 
 function cart_sum($cart_items) {
 	$sum_price = 0;
 	foreach ($cart_items as $cart_item) {
+		// $sum_price = $sum_price + $value['price'] * $value['amount'];
 		$sum_price += $cart_item['price'] * $cart_item['amount'];
 	}
 	return $sum_price;

--- a/lib/model/function.php
+++ b/lib/model/function.php
@@ -62,10 +62,7 @@ function db_select_one(PDO $db, $sql, $params = array()) {
  */
 function db_update(PDO $db, $sql, $params = array()) {
 	$stmt = $db->prepare($sql);
-
 	$result = $stmt->execute($params);
-	var_dump($sql);
-	var_dump($result);
 	return $result;
 }
 

--- a/lib/model/function.php
+++ b/lib/model/function.php
@@ -14,6 +14,10 @@ function db_connect() {
 	try {
 		$db = new PDO($dsn, DB_USER, DB_PASS);
 		$db->exec("SET NAMES 'UTF8'");
+		// エラーモードの設定、例外を投げるようにする。
+		$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+		// prepare機能がない場合エミュレート、今回は使わない(false)。
+		$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 	} catch (PDOException $e) {
 		die('db error: ' . $e->getMessage());
 	}
@@ -59,7 +63,10 @@ function db_select_one(PDO $db, $sql, $params = array()) {
 function db_update(PDO $db, $sql, $params = array()) {
 	$stmt = $db->prepare($sql);
 
-	return $stmt->execute($params);
+	$result = $stmt->execute($params);
+	var_dump($sql);
+	var_dump($result);
+	return $result;
 }
 
 /**

--- a/lib/model/item.php
+++ b/lib/model/item.php
@@ -89,7 +89,7 @@ function item_update_stock($db, $id, $stock) {
  * @param array $cart_items
  * @return boolean
  */
-function item_update_saled($db, $id, $amount) {
+function item_update_sold($db, $id, $amount) {
 	$sql = 
 	'UPDATE items
  	SET stock = stock - ?, update_date = NOW()
@@ -119,4 +119,10 @@ function item_update_status($db, $id, $status) {
  */
 function item_valid_status($status) {
 	return "0" === (string)$status || "1" === (string)$status;
+}
+
+function item_sold($db, $cart_items) {
+	foreach ($cart_items as $cart_item) {
+		item_update_sold($db, $cart_item['item_id'], $cart_item['amount']);
+	}
 }

--- a/lib/model/order.php
+++ b/lib/model/order.php
@@ -1,0 +1,41 @@
+<?php
+
+// 購入履歴登録(DB情報、ユーザID)
+// 購入ごとの投入のため一行ずつ
+function order_history_regist($db, $user_id) {
+    $sql =
+    'INSERT INTO order_histories (user_id, order_datetime)
+    VALUES (?, NOW());';
+    $params = array($user_id);
+    return db_update($db, $sql, $params);
+}
+// 購入明細投入(カート情報登録)(DB情報、履歴のID、購入時のカート内容)
+// カート内の商品ごとに行が増えていくため、foreach文でカート内容一行ごとからカートの商品一行ごとの情報とする
+function order_details_regist($db, $order_history_id, $cart_items) {
+    foreach($cart_items as $cart_item) {
+        // 購入明細投入(カート内商品登録)(DB情報、)
+        order_detail_regist($db, $order_history_id, $cart_item['item_id'], $cart_item['amount']);
+    }
+}
+
+// order_detailsにはhistory_idとitem_idとpurchase_quantityが必要
+// history_idはhistories、item_idはitems
+// purchase_quantityは商品ごとの購入数量
+function order_detail_regist($db, $order_history_id, $item_id, $purchase_quantity) {
+    $sql =
+    'INSERT INTO order_details (order_history_id, item_id, purchase_quantity)
+    VALUES (?, ?, ?);';
+    $params = array($order_history_id, $item_id, $purchase_quantity);
+    db_update($db, $sql, $params);
+}
+
+// 注文履歴を取得する関数(DB情報、ユーザーID)
+// 該当ユーザーIDに紐づく注文履歴を取得
+function order_histories_select ($db, $user_id) {
+    $sql =
+    'SELECT order_histories. user_id, order_datetime. order_datetime
+    FROM order_histories
+    WHERE order_histories.user_id = ?;';
+    $params = array($user_id);
+    return db_select($db, $sql, $params);
+}

--- a/lib/model/order.php
+++ b/lib/model/order.php
@@ -33,7 +33,7 @@ function order_detail_regist($db, $order_history_id, $item_id, $purchase_quantit
 // 該当ユーザーIDに紐づく注文履歴を取得
 function order_histories_select ($db, $user_id) {
     $sql =
-    'SELECT order_histories.user_id, order_datetime. order_datetime
+    'SELECT order_histories.user_id, order_histries.order_datetime
     FROM order_histories
     WHERE order_histories.user_id = ?;';
     $params = array($user_id);

--- a/lib/model/order.php
+++ b/lib/model/order.php
@@ -33,7 +33,7 @@ function order_detail_regist($db, $order_history_id, $item_id, $purchase_quantit
 // 該当ユーザーIDに紐づく注文履歴を取得
 function order_histories_select ($db, $user_id) {
     $sql =
-    'SELECT order_histories. user_id, order_datetime. order_datetime
+    'SELECT order_histories.user_id, order_datetime. order_datetime
     FROM order_histories
     WHERE order_histories.user_id = ?;';
     $params = array($user_id);

--- a/lib/view/history.php
+++ b/lib/view/history.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @license CC BY-NC-SA 4.0
+ * @license https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja
+ * @copyright CodeCamp https://codecamp.jp
+ */
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>購入履歴</title>
+<link href="./assets/bootstrap/dist/css/bootstrap.min.css"
+	rel="stylesheet">
+<link rel="stylesheet" href="./assets/css/style.css">
+
+</head>
+<body>
+<?php include DIR_VIEW_ELEMENT . 'output_navber.php'; ?>
+
+	<div class="container-fluid px-md-3">
+		<div class="row">
+			<div class="col-12">
+				<h1>購入履歴</h1>
+			</div>
+		</div>
+
+<?php 
+var_dump($order_histories_list);
+include DIR_VIEW_ELEMENT . 'output_message.php'; ?>
+
+<?php if ( !empty($order_histories_list)) { ?>
+		<div class="col-xs-12 col-md-10 offset-md-1 cart-list">
+			<div class="row">
+				<table class="table">
+					<thead>
+						<tr>
+							<th rowspan="2" style="width: 30%;"></th>
+							<th colspan="3">商品名</th>
+						</tr>
+						<tr>
+							<th>削除</th>
+							<th>価格</th>
+							<th>数量</th>
+						</tr>
+					</thead>
+					<tbody>
+<?php foreach ( $order_histories_list as $key => $value ) {?>
+						<tr class="<?php echo h((0 === ($key % 2)) ? 'stripe' : '' ); ?>">
+							<td rowspan="2"><img class="w-100"
+								src="<?php echo h(DIR_IMG . $value['img']); ?>"></td>
+							<td colspan="3"><?php echo h($value['name']);?></td>
+						</tr>
+						<tr class="<?php echo h((0 === ($key % 2)) ? 'stripe' : '' ); ?>">
+							<td>
+								<form action="<?php echo h($_SERVER['SCRIPT_NAME']); ?>" method="post">
+									<button type="submit" class="btn btn-danger btn-sm">削除</button>
+									<input type="hidden" name="token" value="<?php echo $_SESSION['token']; ?>">
+									<input type="hidden" name="id" value="<?php echo h($value['id']); ?>">
+									<input type="hidden" name="action" value="delete">
+								</form>
+							</td>
+							<td><?php echo h(number_format($value['price'])); ?>円</td>
+							<td>
+								<form id="form_select_amount<?php echo h($value['id']); ?>" action="<?php echo h($_SERVER['SCRIPT_NAME']); ?>" method="post">
+									<select name="amount" onchange="submit_change_amount(<?php echo h($value['id']); ?>)">
+<?php $max_count = 10; if ((int)$value['amount'] > $max_count){$max_count = (int)$value['amount'];}; ?>
+<?php for ($count = 1; $count <= $max_count; $count++)  { ?>
+										<option value="<?php echo h($count); ?>"
+											<?php if ((int)$value['amount'] === $count){echo 'selected';}; ?>><?php echo h($count);?></option>
+<?php } ?>
+									</select>
+									<input type="hidden" name="token" value="<?php echo $_SESSION['token']; ?>">
+									<input type="hidden" name="id" value="<?php echo h($value['id']); ?>">
+									<input type="hidden" name="action" value="update">
+								</form>
+							</td>
+						</tr>
+<?php } ?>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td></td>
+							<td></td>
+							<td colspan="2">
+								<div>
+									<span>合計</span> <span><?php echo h(number_format($response['total_price'])); ?>円</span>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td colspan="4">
+								<div>
+									<form action="./finish.php" method="post">
+										<input type="hidden" name="token" value="<?php echo $_SESSION['token']; ?>">
+										<button type="submit" class="btn btn-warning btn-lg btn-block">購入する</button>
+									</form>
+								</div>
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+		</div>
+<?php }?>
+	</div>
+	<!-- /.container -->
+	<script src="./assets/js/jquery/1.12.4/jquery.min.js"></script>
+	<script src="./assets/bootstrap/dist/js/bootstrap.min.js"></script>
+	<script type="text/javascript">
+		function submit_change_amount(id) {
+			document.getElementById('form_select_amount' + id).submit();
+		}
+	</script>
+
+</body>
+</html>

--- a/lib/view/history.php
+++ b/lib/view/history.php
@@ -27,7 +27,6 @@
 		</div>
 
 <?php 
-var_dump($order_histories_list);
 include DIR_VIEW_ELEMENT . 'output_message.php'; ?>
 
 <?php if ( !empty($order_histories_list)) { ?>

--- a/webroot/cart.php
+++ b/webroot/cart.php
@@ -24,7 +24,7 @@ require_once DIR_MODEL . 'cart.php';
 	if (empty($response['cart_items'])) {
 		$response['error_msg'] = 'カートに商品がありません。';
 	} else {
-		$response['total_price'] = cart_total_price($db, $_SESSION['user']['id']);
+		$response['total_price'] = cart_sum($response['cart_items']);
 	}
 
 	make_token();

--- a/webroot/finish.php
+++ b/webroot/finish.php
@@ -9,6 +9,7 @@ require_once '../lib/config/const.php';
 require_once DIR_MODEL . 'function.php';
 require_once DIR_MODEL . 'cart.php';
 require_once DIR_MODEL . 'item.php';
+require_once DIR_MODEL . 'order.php';
 
 {
 	session_start();
@@ -40,20 +41,35 @@ function __finish($db, &$response) {
 		$response['error_msg'] = 'リクエストが不適切です。';
 		return;
 	}
-
+	// cart_list関数でカート内の商品を参照し、$response['cart_items']に代入
 	$response['cart_items'] = cart_list($db, $_SESSION['user']['id']);
+	// カートの中身が空かチェック
 	if (empty($response['cart_items'])) {
 		$response['error_msg'] = 'カートに商品がありません。';
 		return;
 	}
+	// $response['total_price'] = cart_total_price($db, $_SESSION['user']['id']);
+	$response['total_price'] = cart_sum($db, $response['cart_items']);
 
-	$response['total_price'] = cart_total_price($db, $_SESSION['user']['id']);
-
-	foreach ($response['cart_items']as $item) {
-		item_update_saled($db, $item['item_id'], $item['amount']);
+    $db->beginTransaction();
+    try {
+        // 在庫を減らす処理
+        item_sold($db, $response['cart_items']);
+        // 購入履歴を追加(購入履歴テーブルに追加)
+        order_history_regist($db, $_SESSION['user']['id']);
+        // history_idを取得
+        $order_history_id = $db->lastInsertId();
+        // 購入明細を追加
+        order_details_regist($db, $order_history_id, $response['cart_items']);
+        // カートから商品を削除する処理
+        cart_clear($db, $_SESSION['user']['id']);
+        // コミット(処理確定)
+        $db->commit();
+        // 完了メッセージを代入
+        $response['result_msg'] = 'ご購入、ありがとうございました。';
+    } catch (PDOException $e) {
+        // ロールバック(処理取消)
+        $db->rollback();
+        throw $e;
 	}
-	
-	cart_clear($db, $_SESSION['user']['id']);
-
-	$response['result_msg'] = 'ご購入、ありがとうございました。';
 }

--- a/webroot/history.php
+++ b/webroot/history.php
@@ -21,7 +21,6 @@ require_once DIR_MODEL . 'order.php';
 	// __update($db, $response);
 	
 	$order_histories_list = order_histories_select($db, $_SESSION['user']['id']);
-    var_dump($order_histories_list);
 
 	if (empty($order_histories_list)) {
 		$response['error_msg'] = '購入履歴がありません。';

--- a/webroot/history.php
+++ b/webroot/history.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @license CC BY-NC-SA 4.0
+ * @license https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja
+ * @copyright CodeCamp https://codecamp.jp
+ */
+require_once '../lib/config/const.php';
+
+require_once DIR_MODEL . 'function.php';
+require_once DIR_MODEL . 'cart.php';
+require_once DIR_MODEL . 'order.php';
+
+{
+	session_start();
+
+	$order_histories_list = array();
+	$db = db_connect();
+
+	check_logined($db);
+
+	// __update($db, $response);
+	
+	$order_histories_list = order_histories_select($db, $_SESSION['user']['id']);
+    var_dump($order_histories_list);
+
+	if (empty($order_histories_list)) {
+		$response['error_msg'] = '購入履歴がありません。';
+	}
+
+	make_token();
+
+	include_once DIR_VIEW . 'history.php';
+}
+
+/**
+ * @param PDO $db
+ * @param array $response
+ */
+function __update($db, &$response) {
+	if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+		return;
+	}
+	if (is_valid_token() === FALSE) {
+		$response['error_msg'] = 'リクエストが不適切です。';
+		return;
+	}
+	if (empty($_POST['action'])) {
+		$response['error_msg'] = 'リクエストが不適切です。';
+		return;
+	}
+	if (empty($_POST['id'])) {
+		$response['error_msg'] = '商品が指定されていません。';
+		return;
+	}
+	switch ($_POST['action']) {
+		case 'update' :
+			if (cart_update($db, $_POST['id'], $_SESSION['user']['id'], $_POST['amount'])) {
+				$response['result_msg'] = '購入数を変更しました。';
+			} else {
+				$response['error_msg'] = '購入数を変更に失敗しました。';
+			}
+			return;
+		case 'delete' :
+			if (cart_delete($db, $_POST['id'], $_SESSION['user']['id'])) {
+				$response['result_msg'] = 'カートから削除しました。';
+			} else {
+				$response['error_msg'] = '削除に失敗しました。';
+			}
+			return;
+	}
+	$response['error_msg'] = 'リクエストが不適切です。';
+	return;
+}


### PR DESCRIPTION
# 概要
注文履歴・明細テーブルへのデータ投入処理

# 変更内容
## model
### order.php
- 新規にorder.phpを作成
- 注文履歴テーブルへの登録関数order_history_regist関数を追加
- 購入明細テーブルへの登録関数order_details_regist関数・order_detail_regist関数を追加
### cart.php
- カート内合計金額の算出関数cart_sum関数を追加
### item.php
- item_update_saled → item_update_sold スペルミス修正
- 購入分の在庫を減らすitem_sold関数を追加
### function.php
- db_connect関数にエラーモードの設定を追加

## webroot
### finish.php
- 在庫減少～メッセージ代入までをトランザクション処理
- 各関数ごとの抽象度を統一する

# 影響範囲
- DB接続やトランザクション処理でエラーが発生した場合メッセージが表示される

# 動作要件
- 特になし

# 補足
- 特になし